### PR TITLE
[2/2] OmniSwitch: add preload task broadcast

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -40,7 +40,9 @@
         <receiver android:name="org.omnirom.omniswitch.SwitchService$RecentsReceiver" >
             <intent-filter>
                 <action android:name="org.omnirom.omniswitch.ACTION_TOGGLE_OVERLAY" />
+                <action android:name="org.omnirom.omniswitch.ACTION_TOGGLE_OVERLAY2" />
                 <action android:name="org.omnirom.omniswitch.ACTION_RESTORE_HOME_STACK" />
+                <action android:name="org.omnirom.omniswitch.ACTION_PRELOAD_TASKS" />
             </intent-filter>
         </receiver>
         <activity

--- a/src/org/omnirom/omniswitch/SwitchManager.java
+++ b/src/org/omnirom/omniswitch/SwitchManager.java
@@ -103,6 +103,28 @@ public class SwitchManager {
         }
     }
 
+    public void showPreloaded() {
+        if (!isShowing()) {
+            if (DEBUG){
+                Log.d(TAG, "showPreloaded");
+            }
+
+            // show immediately
+            mLayout.show();
+        }
+    }
+
+    public void beforePreloadTasks() {
+        if (!isShowing()) {
+            if (DEBUG){
+                Log.d(TAG, "beforePreloadTasks");
+            }
+            clearTasks();
+            mLayout.setHandleRecentsUpdate(true);
+            mRestoreStack = false;
+        }
+    }
+
     public void showHidden() {
         if (!isShowing()) {
             if (DEBUG){

--- a/src/org/omnirom/omniswitch/SwitchService.java
+++ b/src/org/omnirom/omniswitch/SwitchService.java
@@ -56,7 +56,6 @@ public class SwitchService extends Service {
     private static SwitchConfiguration mConfiguration;
     private static int mUserId = -1;
     private Set<String> mPrefKeyFilter = new HashSet<String>();
-
     private static boolean mIsRunning;
     private static boolean mCommitSuicide;
 
@@ -95,8 +94,6 @@ public class SwitchService extends Service {
 
             mReceiver = new RecentsReceiver();
             IntentFilter filter = new IntentFilter();
-            filter.addAction(RecentsReceiver.ACTION_SHOW_OVERLAY);
-            filter.addAction(RecentsReceiver.ACTION_HIDE_OVERLAY);
             filter.addAction(RecentsReceiver.ACTION_HANDLE_HIDE);
             filter.addAction(RecentsReceiver.ACTION_HANDLE_SHOW);
             filter.addAction(Intent.ACTION_USER_SWITCHED);
@@ -166,20 +163,12 @@ public class SwitchService extends Service {
     }
 
     public static class RecentsReceiver extends BroadcastReceiver {
-        public static final String ACTION_SHOW_OVERLAY = "org.omnirom.omniswitch.ACTION_SHOW_OVERLAY";
-        public static final String ACTION_HIDE_OVERLAY = "org.omnirom.omniswitch.ACTION_HIDE_OVERLAY";
         public static final String ACTION_HANDLE_HIDE = "org.omnirom.omniswitch.ACTION_HANDLE_HIDE";
         public static final String ACTION_HANDLE_SHOW = "org.omnirom.omniswitch.ACTION_HANDLE_SHOW";
         public static final String ACTION_TOGGLE_OVERLAY = "org.omnirom.omniswitch.ACTION_TOGGLE_OVERLAY";
+        public static final String ACTION_TOGGLE_OVERLAY2 = "org.omnirom.omniswitch.ACTION_TOGGLE_OVERLAY2";
         public static final String ACTION_RESTORE_HOME_STACK = "org.omnirom.omniswitch.ACTION_RESTORE_HOME_STACK";
-
-        private void show(Context context) {
-            mManager.show();
-        }
-
-        private void hide() {
-            mManager.hide(false);
-        }
+        public static final String ACTION_PRELOAD_TASKS = "org.omnirom.omniswitch.ACTION_PRELOAD_TASKS";
 
         @Override
         public void onReceive(final Context context, Intent intent) {
@@ -188,21 +177,7 @@ public class SwitchService extends Service {
                 if(DEBUG){
                     Log.d(TAG, "onReceive " + action);
                 }
-                if (ACTION_SHOW_OVERLAY.equals(action)) {
-                    if (!mManager.isShowing()) {
-                        if (DEBUG){
-                            Log.d(TAG, "ACTION_SHOW_OVERLAY " + System.currentTimeMillis());
-                        }
-                        show(context);
-                    }
-                } else if (ACTION_HIDE_OVERLAY.equals(action)) {
-                    if (mManager.isShowing()) {
-                        if (DEBUG){
-                            Log.d(TAG, "ACTION_HIDE_OVERLAY " + System.currentTimeMillis());
-                        }
-                        hide();
-                    }
-                } else if (ACTION_HANDLE_SHOW.equals(action)){
+                if (ACTION_HANDLE_SHOW.equals(action)){
                     if (mConfiguration.mDragHandleShow){
                         mManager.getSwitchGestureView().show();
                     }
@@ -213,9 +188,18 @@ public class SwitchService extends Service {
                         Log.d(TAG, "ACTION_TOGGLE_OVERLAY " + System.currentTimeMillis());
                     }
                     if (mManager.isShowing()) {
-                        hide();
+                        mManager.hide(false);
                     } else {
-                        show(context);
+                        mManager.show();
+                    }
+                } else if (ACTION_TOGGLE_OVERLAY2.equals(action)) {
+                    if (DEBUG){
+                        Log.d(TAG, "ACTION_TOGGLE_OVERLAY2 " + System.currentTimeMillis());
+                    }
+                    if (mManager.isShowing()) {
+                        mManager.hide(false);
+                    } else {
+                        mManager.showPreloaded();
                     }
                 } else if (Intent.ACTION_USER_SWITCHED.equals(action)) {
                     int userId = intent.getIntExtra(Intent.EXTRA_USER_HANDLE, -1);
@@ -231,8 +215,20 @@ public class SwitchService extends Service {
                     Log.d(TAG, "ACTION_SHUTDOWN");
                     mManager.shutdownService();
                 } else if (ACTION_RESTORE_HOME_STACK.equals(action)) {
-                    Log.d(TAG, "ACTION_RESTORE_HOME_STACK");
+                    if(DEBUG){
+                        Log.d(TAG, "ACTION_RESTORE_HOME_STACK");
+                    }
                     mManager.restoreHomeStack();
+                } else if (ACTION_PRELOAD_TASKS.equals(action)) {
+                    if(DEBUG){
+                        Log.d(TAG, "ACTION_PRELOAD_TASKS " + System.currentTimeMillis());
+                    }
+                    if (!mManager.isShowing()) {
+                        mManager.beforePreloadTasks();
+                        RecentTasksLoader.getInstance(context).cancelLoadingTasks();
+                        RecentTasksLoader.getInstance(context).setSwitchManager(mManager);
+                        RecentTasksLoader.getInstance(context).preloadTasks();
+                    }
                 }
             } catch(Exception e) {
                 Log.e(TAG,"onReceive", e);

--- a/src/org/omnirom/omniswitch/ui/SwitchLayoutVertical.java
+++ b/src/org/omnirom/omniswitch/ui/SwitchLayoutVertical.java
@@ -281,7 +281,7 @@ public class SwitchLayoutVertical extends AbstractSwitchLayout {
             return;
         }
         if (DEBUG) {
-            Log.d(TAG, "updateRecentsAppsList2");
+            Log.d(TAG, "updateRecentsAppsList before notifyDataSetChanged " + System.currentTimeMillis());
         }
         mRecentListAdapter.notifyDataSetChanged();
 


### PR DESCRIPTION
Broadcast also the preload phase to OmniSwitch to get
an early start on loading tasks like stock recents

The old broadcast API will still be functional for
backward compatibility

Add: relying on broadcasts for all of this gets
worse. It takes a very long time after rebooting
until broadcasts will be processed leaving
users without reaction on button presses even
if the drag handle is already there for some time
But I have currently no better idea then this

Change-Id: Id153ff9763b697c18208dcab72d30ce87e54476a