### PR TITLE
OmniSwitch: fix terrible wrong resizing on compose icons

### DIFF
--- a/src/org/omnirom/omniswitch/ui/BitmapUtils.java
+++ b/src/org/omnirom/omniswitch/ui/BitmapUtils.java
@@ -121,8 +121,8 @@ public class BitmapUtils {
         canvas.setDrawFilter(new PaintFlagsDrawFilter(Paint.ANTI_ALIAS_FLAG,
                 Paint.FILTER_BITMAP_FLAG));
 
-        int width = iconSize;
-        int height = iconSize;
+        int width = size;
+        int height = size;
 
         // TODO
         if (iconBack == null && iconMask == null && iconUpon == null){


### PR DESCRIPTION
dont use dp but pixel else it will get pixelated
when scaled

old: https://drive.google.com/file/d/0B4vRAhHheUkxd1dSUFpURDVKRW8/view?usp=sharing
new: https://drive.google.com/file/d/0B4vRAhHheUkxNWJSdTlZbG9oMnM/view?usp=sharing

Change-Id: I63d1588217876614adf28867fbc8b8d127ec0339